### PR TITLE
Changes for navigation

### DIFF
--- a/src/IrcMonitor.ReactUi/src/components/MenuBar.tsx
+++ b/src/IrcMonitor.ReactUi/src/components/MenuBar.tsx
@@ -53,7 +53,7 @@ export const MenuBar: React.FC<MenuBarProps> = ({
     if (channels && channels.length > 0 && !selectedChannel) {
       const valueInLocalStorage = localStorage.getItem(selectedChannelLocalStorageKey);
 
-      if (valueInLocalStorage) {
+      if (valueInLocalStorage && channels.some((c) => c.guid === valueInLocalStorage)) {
         dispatch(userActions.selectChannel(valueInLocalStorage));
       }
     }

--- a/src/IrcMonitor.ReactUi/src/components/MenuBar.tsx
+++ b/src/IrcMonitor.ReactUi/src/components/MenuBar.tsx
@@ -1,6 +1,6 @@
 import { AppBar, Container, IconButton, MenuItem } from "@mui/material";
-import React from "react";
-import { getChannels, getIsReLogging, User } from "reducers/userReducer";
+import React, { useEffect } from "react";
+import { getChannels, getIsReLogging, getSelectecChannel, User } from "reducers/userReducer";
 import styled from "styled-components";
 import { Menu as MenuIcon } from "@mui/icons-material";
 import { UserMenu } from "./UserMenu";
@@ -33,6 +33,8 @@ const MenuArea = styled.div`
   padding-bottom: 16px;
 `;
 
+const selectedChannelLocalStorageKey = "selectedChannel";
+
 export const MenuBar: React.FC<MenuBarProps> = ({
   handleLogOut,
   user,
@@ -43,10 +45,22 @@ export const MenuBar: React.FC<MenuBarProps> = ({
 
   const channels = useSelector(getChannels);
   const isReLoggingIn = useSelector(getIsReLogging);
+  const selectedChannel = useSelector(getSelectecChannel);
 
   const dispatch = useDispatch();
 
+  useEffect(() => {
+    if (channels && channels.length > 0 && !selectedChannel) {
+      const valueInLocalStorage = localStorage.getItem(selectedChannelLocalStorageKey);
+
+      if (valueInLocalStorage) {
+        dispatch(userActions.selectChannel(valueInLocalStorage));
+      }
+    }
+  }, [channels, selectedChannel, dispatch]);
+
   const handleSelectChannel = (channelId: string | undefined) => {
+    localStorage.setItem(selectedChannelLocalStorageKey, channelId);
     dispatch(userActions.selectChannel(channelId));
   };
 

--- a/src/IrcMonitor.ReactUi/src/containers/OverviewStatisticsView.tsx
+++ b/src/IrcMonitor.ReactUi/src/containers/OverviewStatisticsView.tsx
@@ -52,7 +52,7 @@ export const OverViewStatisticsView: React.FC = () => {
         })
         .catch((err) => {
           setIsLoadingOverViewData(false);
-          alert("Error");
+          console.error(err);
         });
     }
   }, [selectedChannel, apiHook.ircApi]);

--- a/src/IrcMonitor.ReactUi/src/containers/OverviewStatisticsView.tsx
+++ b/src/IrcMonitor.ReactUi/src/containers/OverviewStatisticsView.tsx
@@ -65,7 +65,7 @@ export const OverViewStatisticsView: React.FC = () => {
     const correspondingRow = response.rows[index];
 
     if (correspondingRow) {
-      navigate(`${routes.statistics}/${correspondingRow.identifier}/${selectedChannel}`);
+      navigate(`${routes.statistics}/${correspondingRow.identifier}`);
     }
   };
 

--- a/src/IrcMonitor.ReactUi/src/containers/YearlyStatistics.tsx
+++ b/src/IrcMonitor.ReactUi/src/containers/YearlyStatistics.tsx
@@ -1,5 +1,4 @@
 import { Box, FormControl, InputLabel, MenuItem, Select } from "@mui/material";
-import { userActions } from "actions/userActions";
 import { IrcGetHourlyStatisticsRequest, StatisticsVmBase, YearlyStatisticsVm } from "api";
 import { BarChartComponent } from "components/BarChartComponent";
 import { NickStatisticsDialog } from "components/NickStatisticsDialog";
@@ -7,7 +6,7 @@ import { AppContentWrapper } from "framework/AppContentWrapper";
 import { useApiHook } from "hooks/useApiHook";
 import moment from "moment";
 import React, { useEffect, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 import { useNavigate, useParams } from "react-router-dom";
 import { getChannels, getSelectecChannel } from "reducers/userReducer";
 import { dateFormat } from "utilities/dateUtils";
@@ -19,7 +18,6 @@ const years = [
 
 export const YearlyStatisticsView: React.FC = () => {
   const { year } = useParams<{ year: string }>();
-  const { channel } = useParams<{ channel: string }>();
   const selectedChannel = useSelector(getSelectecChannel);
   const channels = useSelector(getChannels);
   const [selectedYear, setSelectedYear] = useState<number | undefined>(undefined);
@@ -30,7 +28,6 @@ export const YearlyStatisticsView: React.FC = () => {
   const [userStatisticsRequest, setUserStatisticsRequest] = useState<
     IrcGetHourlyStatisticsRequest | undefined
   >(undefined);
-  const dispatch = useDispatch();
   const navigate = useNavigate();
 
   const apiHook = useApiHook();
@@ -39,12 +36,6 @@ export const YearlyStatisticsView: React.FC = () => {
       setSelectedYear(parseInt(year, 10));
     }
   }, [year]);
-
-  useEffect(() => {
-    if (channel) {
-      dispatch(userActions.selectChannel(channel));
-    }
-  }, [channel, dispatch]);
 
   useEffect(() => {
     if (selectedYear !== undefined && selectedChannel && apiHook.ircApi) {

--- a/src/IrcMonitor.ReactUi/src/containers/YearlyStatistics.tsx
+++ b/src/IrcMonitor.ReactUi/src/containers/YearlyStatistics.tsx
@@ -48,7 +48,7 @@ export const YearlyStatisticsView: React.FC = () => {
         })
         .catch((er) => {
           setIsLoadingYearlyData(false);
-          alert(er);
+          console.error(er);
         });
 
       apiHook.ircApi
@@ -124,8 +124,9 @@ export const YearlyStatisticsView: React.FC = () => {
             {years.map((y) => (
               <MenuItem
                 value={y}
+                key={`year-${y}`}
                 onClick={() => {
-                  setSelectedYear(y);
+                  navigate(`${routes.statistics}/${y}`);
                 }}
               >
                 {y}

--- a/src/IrcMonitor.ReactUi/src/utilities/routes.ts
+++ b/src/IrcMonitor.ReactUi/src/utilities/routes.ts
@@ -2,5 +2,5 @@ export const routes = {
   main: "/",
   browse: "/browse",
   statistics: "/statistics",
-  yearlyStatistics: "/statistics/:year/:channel"
+  yearlyStatistics: "/statistics/:year"
 };

--- a/src/IrcMonitor.WebUI/IrcMonitor.WebUI.csproj
+++ b/src/IrcMonitor.WebUI/IrcMonitor.WebUI.csproj
@@ -27,6 +27,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.0-rc.2.22476.2" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="7.0.0-rc.2.22476.2" />
     <PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="7.0.0-rc.2.22476.2" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaServices" Version="3.1.32" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="7.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.0-rc.2.22472.11" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0-rc.2.22472.11" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.0-rc.2.22472.11" />

--- a/src/IrcMonitor.WebUI/Program.cs
+++ b/src/IrcMonitor.WebUI/Program.cs
@@ -1,3 +1,4 @@
+using System;
 using IrcMonitor.Infrastructure.Persistence;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -71,7 +72,9 @@ app.MapControllerRoute(
     name: "default",
     pattern: "{controller}/{action=Index}/{id?}");
 
-app.MapRazorPages();
-
+app.UseSpa(spa =>
+{
+    spa.Options.SourcePath = "wwwroot";
+});
 
 app.Run();


### PR DESCRIPTION
- Store the selected channel id in local storage, for persistance. When app loads, use that selection.
- In the yearly statistics page, keep just the year in the navigation URL.
- Added ``UseSpa()`` middleware in the backend, so routes not matching with any backend endpoints get redirected to the UI.