### PR TITLE
Show only channels having a predefined number of rows

### DIFF
--- a/src/IrcMonitor.Application/Irc/Queries/GetIrcChannelsQuery.cs
+++ b/src/IrcMonitor.Application/Irc/Queries/GetIrcChannelsQuery.cs
@@ -35,7 +35,7 @@ public class GetIrcChannelsQueryHandler : IRequestHandler<GetIrcChannelsQuery, G
             query = query.Where(x => _identityService.GetAccessibleChannels().Contains(x.Id.ToString()));
         }
 
-        query = query.Where(x => x.TimeGroupedRows.Sum(g => g.Count) > _ircStatisticsSettings.MinRowCountForChannel );
+        query = query.Where(x => x.TimeGroupedRows.Sum(g => g.Count) >= _ircStatisticsSettings.MinRowCountForChannel );
 
         var res = await query.ProjectTo<IrcChannelDto>(_mapper.ConfigurationProvider).ToListAsync(cancellationToken);
 

--- a/src/IrcMonitor.Domain/Entities/IrcRow.cs
+++ b/src/IrcMonitor.Domain/Entities/IrcRow.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace IrcMonitor.Domain.Entities;
+﻿namespace IrcMonitor.Domain.Entities;
 public class IrcRow
 {
     public long Id { get; set; }

--- a/src/IrcMonitor.Domain/Models/IrcStatisticsSettings.cs
+++ b/src/IrcMonitor.Domain/Models/IrcStatisticsSettings.cs
@@ -4,4 +4,5 @@
 public class IrcStatisticsSettings
 {
     public int NickTresholdLimit { get; set; }
+    public int MinRowCountForChannel { get; set; }
 }

--- a/src/IrcMonitor.ReactUi/src/actions/userActions.ts
+++ b/src/IrcMonitor.ReactUi/src/actions/userActions.ts
@@ -9,7 +9,8 @@ export enum UserActionTypes {
   StoreUserChannels = "User/StoreUserChannels",
   SelectChannel = "User/SelectChannel",
   SetIsLoggingIn = "User/SetIsLoggingIn",
-  SetIsReLoggingIn = "User/SetIsReLoggingIn"
+  SetIsReLoggingIn = "User/SetIsReLoggingIn",
+  SetIsLoadingChannels = "User/IsLoadingChannels"
 }
 
 export interface StoreGoogleAuthInfo extends Action {
@@ -46,6 +47,11 @@ export interface SetIsReLoggingIn extends Action {
   isReLogging: boolean;
 }
 
+export interface SetIsLoadingChannels extends Action {
+  type: UserActionTypes.SetIsLoadingChannels;
+  isLoadingChannels: boolean;
+}
+
 export const userActions = {
   storeUserInfo: (userInfo: UserVm): StoreGoogleAuthInfo => ({
     type: UserActionTypes.StoreUserInfo,
@@ -73,6 +79,10 @@ export const userActions = {
   setIsReLoggingIn: (isReLogging: boolean): SetIsReLoggingIn => ({
     type: UserActionTypes.SetIsReLoggingIn,
     isReLogging
+  }),
+  setIsLoadingChannels: (isLoadingChannels: boolean): SetIsLoadingChannels => ({
+    type: UserActionTypes.SetIsLoadingChannels,
+    isLoadingChannels
   })
 };
 
@@ -83,4 +93,5 @@ export type UserActions =
   | StoreUserChannels
   | SelectChannel
   | SetIsUserLoggingIn
-  | SetIsReLoggingIn;
+  | SetIsReLoggingIn
+  | SetIsLoadingChannels;

--- a/src/IrcMonitor.ReactUi/src/framework/App.tsx
+++ b/src/IrcMonitor.ReactUi/src/framework/App.tsx
@@ -51,15 +51,20 @@ export const App: React.FC<AppProps> = (props) => {
   useEffect(() => {
     if (apiHook.ircApi) {
       const api = apiHook.ircApi;
+      dispatch(userActions.setIsLoadingChannels(true));
       api
         .ircGetIrcChannels({ exclude: undefined })
         .then((res) => {
           if (res.channels) {
+            dispatch(userActions.setIsLoadingChannels(false));
             dispatch(userActions.storeUserChannels(res.channels));
           }
         })
         .catch((err) => {
           console.error(err);
+        })
+        .finally(() => {
+          dispatch(userActions.setIsLoadingChannels(false));
         });
     }
   }, [dispatch, apiHook.ircApi]);

--- a/src/IrcMonitor.ReactUi/src/framework/AppContentWrapper.tsx
+++ b/src/IrcMonitor.ReactUi/src/framework/AppContentWrapper.tsx
@@ -1,7 +1,7 @@
 import { Backdrop, CircularProgress, Typography } from "@mui/material";
 import React from "react";
 import { useSelector } from "react-redux";
-import { getIsLoggingIn } from "reducers/userReducer";
+import { getIsLoadingChannels, getIsLoggingIn } from "reducers/userReducer";
 import styled from "styled-components";
 
 export interface AppContentWrapperProps {
@@ -30,11 +30,12 @@ const OuterContainer = styled.div`
 
 export const AppContentWrapper: React.FC<AppContentWrapperProps> = (props) => {
   const isLoggingIn = useSelector(getIsLoggingIn);
+  const isLoadingChannels = useSelector(getIsLoadingChannels);
   return (
     <>
       <Backdrop
         sx={{ color: "#fff", zIndex: (theme) => theme.zIndex.drawer + 1 }}
-        open={props.isLoading || isLoggingIn}
+        open={props.isLoading || isLoggingIn || isLoadingChannels}
       >
         <CircularProgress color="inherit" />
       </Backdrop>

--- a/src/IrcMonitor.ReactUi/src/reducers/userReducer.ts
+++ b/src/IrcMonitor.ReactUi/src/reducers/userReducer.ts
@@ -23,6 +23,7 @@ export interface UserState {
   isLoggingIn: boolean;
   userVm: UserVm | undefined;
   isReLogIn: boolean;
+  isLoadingChannels: boolean;
 }
 
 const defaultState: UserState = {
@@ -31,7 +32,8 @@ const defaultState: UserState = {
   selectedChannel: undefined,
   isLoggingIn: false,
   userVm: undefined,
-  isReLogIn: false
+  isReLogIn: false,
+  isLoadingChannels: false
 };
 
 export function userReducer(state: UserState = defaultState, action: UserActions): UserState {
@@ -86,6 +88,11 @@ export function userReducer(state: UserState = defaultState, action: UserActions
         draft.isReLogIn = action.isReLogging;
       });
       break;
+    case UserActionTypes.SetIsLoadingChannels:
+      state = produce(state, (draft) => {
+        draft.isLoadingChannels = action.isLoadingChannels;
+      });
+      break;
   }
   return state;
 }
@@ -105,3 +112,5 @@ export const getIsLoggingIn = (state: AppState): boolean => state.user.isLogging
 export const getUserVm = (state: AppState): UserVm | undefined => state.user.userVm;
 
 export const getIsReLogging = (state: AppState): boolean => state.user.isReLogIn;
+
+export const getIsLoadingChannels = (state: AppState): boolean => state.user.isLoadingChannels;

--- a/src/IrcMonitor.WebUI/appsettings.json
+++ b/src/IrcMonitor.WebUI/appsettings.json
@@ -18,7 +18,8 @@
     }
   },
   "IrcStatisticsSettings": {
-    "NickTresholdLimit": 10
+    "NickTresholdLimit": 10,
+    "MinRowCountForChannel": 100
   },
   "AuthenticationSettings": {
     "GoogleAuth": {


### PR DESCRIPTION
- Added an appsetting to define the min amount of rows, so that the channel appears in the dropdown.
- In the ``GetChannelsQuery``, use the ``TimeGroupedRows`` table for fetching the desired channels.
- Added loading spinner in the UI when fetching channels.