### PR TITLE
Use the hourly query to fetch hour statistics in the yearly statistics page

### DIFF
--- a/src/IrcMonitor.Application/Statistics/Queries/GetYearlyStatisticsQuery.cs
+++ b/src/IrcMonitor.Application/Statistics/Queries/GetYearlyStatisticsQuery.cs
@@ -51,7 +51,6 @@ public class GetYearlyStatisticsQueryHandler : IRequestHandler<GetYearlyStatisti
 
         var query = _context.TimeGroupedRows.Where(x => x.ChannelId == channel.Id && x.Year == request.Year);
 
-
         var monthlyQuery = query.GroupBy(x => x.Month).Select(x => new BarChartRow()
         {
             Label = "",
@@ -60,13 +59,6 @@ public class GetYearlyStatisticsQueryHandler : IRequestHandler<GetYearlyStatisti
         });
 
         var months = Enumerable.Range(1, 12);
-
-        var hourlyQuery = query.GroupBy(x => x.Hour).OrderBy(x => x.Key).Select(x => new BarChartRow() {
-        
-            Label = x.Key.ToString(),
-            Identifier = x.Key,
-            Value = x.Sum(x => x.Count)
-        });
 
         var montlyStatistics = (await monthlyQuery.OrderBy(x => x.Identifier).ToListAsync(cancellationToken)).Select(x => new BarChartRow()
         {
@@ -82,12 +74,9 @@ public class GetYearlyStatisticsQueryHandler : IRequestHandler<GetYearlyStatisti
             Label = CultureInfo.CurrentCulture.DateTimeFormat.GetMonthName(m)
         }));
 
-        var hourlyStatistics = await hourlyQuery.ToListAsync(cancellationToken);
-
         return new YearlyStatisticsVm()
         {
             MonthlyRows = montlyStatistics.OrderBy(x => x.Identifier).ToList(),
-            HourlyRows = hourlyStatistics,
             Channel = channel.Name,
             Year = request.Year,
         };

--- a/src/IrcMonitor.Application/Statistics/Queries/YearlyStatisticsVm.cs
+++ b/src/IrcMonitor.Application/Statistics/Queries/YearlyStatisticsVm.cs
@@ -5,8 +5,6 @@ public class YearlyStatisticsVm
 {
     public List<BarChartRow> MonthlyRows { get; set; } 
 
-    public List<BarChartRow> HourlyRows { get; set; }
-
     public string Channel { get; set; }
 
     public int Year { get; set; }

--- a/src/IrcMonitor.ReactUi/src/api/models/YearlyStatisticsVm.ts
+++ b/src/IrcMonitor.ReactUi/src/api/models/YearlyStatisticsVm.ts
@@ -34,12 +34,6 @@ export interface YearlyStatisticsVm {
     monthlyRows?: Array<BarChartRow>;
     /**
      * 
-     * @type {Array<BarChartRow>}
-     * @memberof YearlyStatisticsVm
-     */
-    hourlyRows?: Array<BarChartRow>;
-    /**
-     * 
      * @type {string}
      * @memberof YearlyStatisticsVm
      */
@@ -72,7 +66,6 @@ export function YearlyStatisticsVmFromJSONTyped(json: any, ignoreDiscriminator: 
     return {
         
         'monthlyRows': !exists(json, 'monthlyRows') ? undefined : ((json['monthlyRows'] as Array<any>).map(BarChartRowFromJSON)),
-        'hourlyRows': !exists(json, 'hourlyRows') ? undefined : ((json['hourlyRows'] as Array<any>).map(BarChartRowFromJSON)),
         'channel': !exists(json, 'channel') ? undefined : json['channel'],
         'year': !exists(json, 'year') ? undefined : json['year'],
     };
@@ -88,7 +81,6 @@ export function YearlyStatisticsVmToJSON(value?: YearlyStatisticsVm | null): any
     return {
         
         'monthlyRows': value.monthlyRows === undefined ? undefined : ((value.monthlyRows as Array<any>).map(BarChartRowToJSON)),
-        'hourlyRows': value.hourlyRows === undefined ? undefined : ((value.hourlyRows as Array<any>).map(BarChartRowToJSON)),
         'channel': value.channel,
         'year': value.year,
     };


### PR DESCRIPTION
- Use the hourly query to fetch hour statistics in the yearly statistics page
- ``GetYearlyStatisticsQuery`` now to return only count per month.