### PR TITLE
Functionality for forming aggregates daily / package updates

### DIFF
--- a/src/IrcMonitor.Application/Common/Interfaces/IApplicationDbContext.cs
+++ b/src/IrcMonitor.Application/Common/Interfaces/IApplicationDbContext.cs
@@ -17,4 +17,6 @@ public interface IApplicationDbContext
     DbSet<TimeGroupedRow> TimeGroupedRows { get; }
 
     Task<int> SaveChangesAsync(CancellationToken cancellationToken);
+
+    Task Upsert<T>(IEnumerable<T> entities, CancellationToken cancellationToken) where T : class;
 }

--- a/src/IrcMonitor.Application/Common/Interfaces/IRowInsertService.cs
+++ b/src/IrcMonitor.Application/Common/Interfaces/IRowInsertService.cs
@@ -1,5 +1,7 @@
-﻿namespace IrcMonitor.Application.Common.Interfaces;
+﻿using IrcMonitor.Domain.Models;
+
+namespace IrcMonitor.Application.Common.Interfaces;
 public interface IRowInsertService
 {
-    public Task ProcessFile(string fileName, string content);
+    public Task<ProcessLogFileReturnModel> ProcessFile(string fileName, string content);
 }

--- a/src/IrcMonitor.Application/Common/Interfaces/IStatisticsService.cs
+++ b/src/IrcMonitor.Application/Common/Interfaces/IStatisticsService.cs
@@ -2,8 +2,8 @@
 namespace IrcMonitor.Application.Common.Interfaces;
 public interface IStatisticsService
 {
-    Task PopulateChannelStatistics();
+    Task PopulateChannelStatistics(CancellationToken cancellationToken);
 
 
-    Task UpdateChannelMonthlyStatistics(int channelId, int year, int month, int day);
+    Task UpdateChannelMonthlyStatistics(int channelId, int year, int month, int day, CancellationToken cancellationToken);
 }

--- a/src/IrcMonitor.Application/Common/Interfaces/IStatisticsService.cs
+++ b/src/IrcMonitor.Application/Common/Interfaces/IStatisticsService.cs
@@ -5,5 +5,5 @@ public interface IStatisticsService
     Task PopulateChannelStatistics(CancellationToken cancellationToken);
 
 
-    Task UpdateChannelMonthlyStatistics(int channelId, int year, int month, int day, CancellationToken cancellationToken);
+    Task UpdateChannelMonthlyStatistics(Guid channelId, int year, int month, int day, CancellationToken cancellationToken);
 }

--- a/src/IrcMonitor.Application/Common/Interfaces/IStatisticsService.cs
+++ b/src/IrcMonitor.Application/Common/Interfaces/IStatisticsService.cs
@@ -3,4 +3,7 @@ namespace IrcMonitor.Application.Common.Interfaces;
 public interface IStatisticsService
 {
     Task PopulateChannelStatistics();
+
+
+    Task UpdateChannelMonthlyStatistics(int channelId, int year, int month, int day);
 }

--- a/src/IrcMonitor.Application/Irc/Queries/GetIrcChannelsQuery.cs
+++ b/src/IrcMonitor.Application/Irc/Queries/GetIrcChannelsQuery.cs
@@ -29,7 +29,7 @@ public class GetIrcChannelsQueryHandler : IRequestHandler<GetIrcChannelsQuery, G
     }
     public async Task<GetIrcChannelsVm> Handle(GetIrcChannelsQuery request, CancellationToken cancellationToken)
     {
-        IQueryable<IrcChannel> query = _context.IrcChannels;
+        IQueryable<IrcChannel> query = _context.IrcChannels.Where(x => x.IsActive);
         if (!_identityService.IsAdmin)
         {
             query = query.Where(x => _identityService.GetAccessibleChannels().Contains(x.Id.ToString()));

--- a/src/IrcMonitor.Application/IrcMonitor.Application.csproj
+++ b/src/IrcMonitor.Application/IrcMonitor.Application.csproj
@@ -18,9 +18,9 @@
         <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
         <PackageReference Include="BouncyCastle.NetCore" Version="2.2.1" />
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="10.3.4" />
-        <PackageReference Include="Google.Apis.Auth" Version="1.62.0" />
+        <PackageReference Include="Google.Apis.Auth" Version="1.62.1" />
         <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0-rc.2.22472.11" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.11" />
         <PackageReference Include="System.Linq.Dynamic.Core" Version="1.2.24" />
     </ItemGroup>
 

--- a/src/IrcMonitor.Domain/Models/Functions/FormDailyAggregate.cs
+++ b/src/IrcMonitor.Domain/Models/Functions/FormDailyAggregate.cs
@@ -1,7 +1,0 @@
-﻿namespace IrcMonitor.Domain.Models.Functions;
-public class FormDailyAggregate
-{
-    public int ChannelId { get; set; }
-    public int Year { get; set; }
-    public int Day { get; set; }
-}

--- a/src/IrcMonitor.Domain/Models/Functions/FormDailyAggregate.cs
+++ b/src/IrcMonitor.Domain/Models/Functions/FormDailyAggregate.cs
@@ -1,0 +1,7 @@
+﻿namespace IrcMonitor.Domain.Models.Functions;
+public class FormDailyAggregate
+{
+    public int ChannelId { get; set; }
+    public int Year { get; set; }
+    public int Day { get; set; }
+}

--- a/src/IrcMonitor.Domain/Models/Functions/FormDailyAggregateModel.cs
+++ b/src/IrcMonitor.Domain/Models/Functions/FormDailyAggregateModel.cs
@@ -1,0 +1,6 @@
+﻿namespace IrcMonitor.Domain.Models.Functions;
+public class FormDailyAggregateModel
+{
+    public required Guid ChannelId { get; set; }
+    public required DateTime Date { get; set; }
+}

--- a/src/IrcMonitor.Domain/Models/ProcessLogFileReturnModel.cs
+++ b/src/IrcMonitor.Domain/Models/ProcessLogFileReturnModel.cs
@@ -1,7 +1,7 @@
 ﻿namespace IrcMonitor.Domain.Models;
 public class ProcessLogFileReturnModel
 {
-    public int ChannelId { get; set; }
+    public IrcChannel Channel { get; set; }
     public int InsertedRowCount { get; set; }
     public DateTime Date { get; set; }
 }

--- a/src/IrcMonitor.Domain/Models/ProcessLogFileReturnModel.cs
+++ b/src/IrcMonitor.Domain/Models/ProcessLogFileReturnModel.cs
@@ -1,0 +1,7 @@
+﻿namespace IrcMonitor.Domain.Models;
+public class ProcessLogFileReturnModel
+{
+    public int ChannelId { get; set; }
+    public int InsertedRowCount { get; set; }
+    public DateTime Date { get; set; }
+}

--- a/src/IrcMonitor.Infrastructure/IrcMonitor.Infrastructure.csproj
+++ b/src/IrcMonitor.Infrastructure/IrcMonitor.Infrastructure.csproj
@@ -12,12 +12,12 @@
         <PackageReference Include="Azure.Identity" Version="1.10.1" />
         <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.5.0" />
         <PackageReference Include="CsvHelper" Version="15.0.10" />
-        <PackageReference Include="Google.Apis.Auth" Version="1.62.0" />
-        <PackageReference Include="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Version="7.0.0-rc.2.22476.2" />
-        <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.0-rc.2.22476.2" />
-        <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.0-rc.2.22476.2" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0-rc.2.22472.11" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.0-rc.2.22472.11" />
+        <PackageReference Include="Google.Apis.Auth" Version="1.62.1" />
+        <PackageReference Include="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Version="7.0.11" />
+        <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.11" />
+        <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.11" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.11" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.11" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/IrcMonitor.Infrastructure/IrcMonitor.Infrastructure.csproj
+++ b/src/IrcMonitor.Infrastructure/IrcMonitor.Infrastructure.csproj
@@ -12,6 +12,7 @@
         <PackageReference Include="Azure.Identity" Version="1.10.1" />
         <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.5.0" />
         <PackageReference Include="CsvHelper" Version="15.0.10" />
+        <PackageReference Include="EFCore.BulkExtensions" Version="7.1.6" />
         <PackageReference Include="Google.Apis.Auth" Version="1.62.1" />
         <PackageReference Include="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Version="7.0.11" />
         <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.11" />

--- a/src/IrcMonitor.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/src/IrcMonitor.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using EFCore.BulkExtensions;
 using IrcMonitor.Application.Common.Interfaces;
 using IrcMonitor.Domain.Entities;
 using IrcMonitor.Infrastructure.Persistence.Interceptors;
@@ -32,10 +33,16 @@ public class ApplicationDbContext : DbContext, IApplicationDbContext
         builder.ApplyConfigurationsFromAssembly(Assembly.GetExecutingAssembly());
 
         base.OnModelCreating(builder);
+
     }
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
         optionsBuilder.AddInterceptors(_auditableEntitySaveChangesInterceptor);
+    }
+
+    public async Task Upsert<T>(IEnumerable<T> entities, CancellationToken cancellationToken) where T : class
+    {
+        await this.BulkInsertOrUpdateAsync(entities, cancellationToken: cancellationToken);
     }
 }

--- a/src/IrcMonitor.Infrastructure/Persistence/Configurations/IrcChannelConfiguration.cs
+++ b/src/IrcMonitor.Infrastructure/Persistence/Configurations/IrcChannelConfiguration.cs
@@ -15,6 +15,5 @@ public class IrcChannelConfiguration : IEntityTypeConfiguration<IrcChannel>
         builder.Property(x => x.Name).IsRequired();
 
         builder.HasIndex(x => x.Name).IsUnique();
-        builder.HasQueryFilter(x => x.IsActive);
     }
 }

--- a/src/IrcMonitor.Infrastructure/Services/RowInsertService.cs
+++ b/src/IrcMonitor.Infrastructure/Services/RowInsertService.cs
@@ -86,7 +86,7 @@ public class RowInsertService : IRowInsertService
 
         return new ProcessLogFileReturnModel()
         {
-            ChannelId = correspondingChannel.Id,
+            Channel = correspondingChannel,
             InsertedRowCount = ircRowsToInsert.Count,
             Date = date
         };

--- a/src/IrcMonitor.Infrastructure/Services/RowInsertService.cs
+++ b/src/IrcMonitor.Infrastructure/Services/RowInsertService.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text.RegularExpressions;
 using IrcMonitor.Application.Common.Interfaces;
 using IrcMonitor.Domain.Entities;
+using IrcMonitor.Domain.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
@@ -14,13 +15,13 @@ public class RowInsertService : IRowInsertService
         _context = context;
         _logger = loggerFactory.CreateLogger<RowInsertService>();
     }
-
-    public async Task ProcessFile(string fileName, string content)
+    
+    public async Task<ProcessLogFileReturnModel> ProcessFile(string fileName, string content)
     {
 
         if (await _context.ProcessedLogFiles.AnyAsync(x => x.FileName == fileName)) {
             _logger.LogWarning($"File {fileName} already processed");
-            return;
+            return null;
         }
 
         // Capture everything before the last dot, then capture the date pattern, followed by ".log"
@@ -82,5 +83,12 @@ public class RowInsertService : IRowInsertService
         await _context.SaveChangesAsync(CancellationToken.None);
 
         _logger.LogInformation($"Finished processing file {fileName}. Inserted a total of {ircRowsToInsert.Count} rows");
+
+        return new ProcessLogFileReturnModel()
+        {
+            ChannelId = correspondingChannel.Id,
+            InsertedRowCount = ircRowsToInsert.Count,
+            Date = date
+        };
     }
 }

--- a/src/IrcMonitor.Infrastructure/Services/StatisticsService.cs
+++ b/src/IrcMonitor.Infrastructure/Services/StatisticsService.cs
@@ -37,4 +37,27 @@ public class StatisticsService : IStatisticsService
         _logger.LogInformation("Channel statistics populated");
 
     }
+
+    public async Task UpdateChannelMonthlyStatistics(int channelId, int year, int month, int day)
+    {
+        // The new grouped rows, hour / channel / nick.
+        var groupedQuery = _context.IrcRows.Where(x => x.Channel.Id == channelId &&
+
+        x.TimeStamp.Year == year && x.TimeStamp.Month == month
+        ).GroupBy(x => new { x.TimeStamp.Hour, x.ChannelId, x.Nick });
+
+        var newRows =  groupedQuery.Select(x => new TimeGroupedRow() {
+            Year = year,
+            Month = month,
+            Hour = x.Key.Hour,
+            ChannelId = channelId,
+            Count = x.Count(),
+            Nick = x.Key.Nick
+        });
+
+
+        var curRows = _context.TimeGroupedRows.Where(x => x.ChannelId == channelId && x.Year == year && x.Month == month);
+
+        return;
+    }
 }

--- a/src/IrcMonitor.Infrastructure/Services/StatisticsService.cs
+++ b/src/IrcMonitor.Infrastructure/Services/StatisticsService.cs
@@ -46,8 +46,10 @@ public class StatisticsService : IStatisticsService
 
         if (channel == null)
         {
-            throw new NotFoundException();
+            throw new NotFoundException($"No channel found with guid / id {channelId}");
         }
+
+        _logger.LogInformation($"Found channel {channel.Name} with guid {channelId}. Start updating monthly statistics.");
 
         // The new grouped rows, hour / channel / nick.
         var groupedQuery = _context.IrcRows.Where(x => x.Channel.Id == channel.Id &&
@@ -67,6 +69,8 @@ public class StatisticsService : IStatisticsService
 
         await _context.Upsert(newRows, cancellationToken);
         await _context.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation($"Monthly statistics updated for channel {channel.Name} for year: {year}/ month: {month}");
 
     }
 }

--- a/src/IrcMonitor.Infrastructure/Services/StatisticsService.cs
+++ b/src/IrcMonitor.Infrastructure/Services/StatisticsService.cs
@@ -39,10 +39,10 @@ public class StatisticsService : IStatisticsService
 
     }
 
-    public async Task UpdateChannelMonthlyStatistics(int channelId, int year, int month, int day, CancellationToken cancellationToken)
+    public async Task UpdateChannelMonthlyStatistics(Guid channelId, int year, int month, int day, CancellationToken cancellationToken)
     {
 
-        var channel = await _context.IrcChannels.FirstOrDefaultAsync(x => x.Id == channelId, cancellationToken);
+        var channel = await _context.IrcChannels.FirstOrDefaultAsync(x => x.Guid == channelId, cancellationToken);
 
         if (channel == null)
         {
@@ -50,7 +50,7 @@ public class StatisticsService : IStatisticsService
         }
 
         // The new grouped rows, hour / channel / nick.
-        var groupedQuery = _context.IrcRows.Where(x => x.Channel.Id == channelId &&
+        var groupedQuery = _context.IrcRows.Where(x => x.Channel.Id == channel.Id &&
 
         x.TimeStamp.Year == year && x.TimeStamp.Month == month
         ).GroupBy(x => new { x.TimeStamp.Hour, x.ChannelId, x.Nick });
@@ -59,14 +59,13 @@ public class StatisticsService : IStatisticsService
             Year = year,
             Month = month,
             Hour = x.Key.Hour,
-            ChannelId = channelId,
+            ChannelId = channel.Id,
             Count = x.Count(),
             Nick = x.Key.Nick,
             Updated = DateTime.UtcNow, 
         }).ToListAsync();
 
         await _context.Upsert(newRows, cancellationToken);
-
         await _context.SaveChangesAsync(cancellationToken);
 
     }

--- a/src/IrcMonitor.Infrastructure/Services/StatisticsService.cs
+++ b/src/IrcMonitor.Infrastructure/Services/StatisticsService.cs
@@ -1,4 +1,5 @@
-﻿using IrcMonitor.Application.Common.Interfaces;
+﻿using IrcMonitor.Application.Common.Exceptions;
+using IrcMonitor.Application.Common.Interfaces;
 using IrcMonitor.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -13,7 +14,7 @@ public class StatisticsService : IStatisticsService
         _context = context;
         _logger = loggerFactory.CreateLogger<StatisticsService>();
     }
-    public async Task PopulateChannelStatistics()
+    public async Task PopulateChannelStatistics(CancellationToken cancellationToken)
     {
         _logger.LogInformation("Start populating channel statistics");
 
@@ -30,34 +31,43 @@ public class StatisticsService : IStatisticsService
             Month = x.Key.Month,
             Count = x.Count(),
             Updated = DateTime.UtcNow
-        }));
+        }), cancellationToken);
 
-        await _context.SaveChangesAsync(CancellationToken.None);
+        await _context.SaveChangesAsync(cancellationToken);
 
         _logger.LogInformation("Channel statistics populated");
 
     }
 
-    public async Task UpdateChannelMonthlyStatistics(int channelId, int year, int month, int day)
+    public async Task UpdateChannelMonthlyStatistics(int channelId, int year, int month, int day, CancellationToken cancellationToken)
     {
+
+        var channel = await _context.IrcChannels.FirstOrDefaultAsync(x => x.Id == channelId, cancellationToken);
+
+        if (channel == null)
+        {
+            throw new NotFoundException();
+        }
+
         // The new grouped rows, hour / channel / nick.
         var groupedQuery = _context.IrcRows.Where(x => x.Channel.Id == channelId &&
 
         x.TimeStamp.Year == year && x.TimeStamp.Month == month
         ).GroupBy(x => new { x.TimeStamp.Hour, x.ChannelId, x.Nick });
 
-        var newRows =  groupedQuery.Select(x => new TimeGroupedRow() {
+        var newRows =  await groupedQuery.Select(x => new TimeGroupedRow() {
             Year = year,
             Month = month,
             Hour = x.Key.Hour,
             ChannelId = channelId,
             Count = x.Count(),
-            Nick = x.Key.Nick
-        });
+            Nick = x.Key.Nick,
+            Updated = DateTime.UtcNow, 
+        }).ToListAsync();
 
+        await _context.Upsert(newRows, cancellationToken);
 
-        var curRows = _context.TimeGroupedRows.Where(x => x.ChannelId == channelId && x.Year == year && x.Month == month);
+        await _context.SaveChangesAsync(cancellationToken);
 
-        return;
     }
 }

--- a/src/IrcMonitor.Infrastructure/Services/StatisticsService.cs
+++ b/src/IrcMonitor.Infrastructure/Services/StatisticsService.cs
@@ -70,7 +70,7 @@ public class StatisticsService : IStatisticsService
         await _context.Upsert(newRows, cancellationToken);
         await _context.SaveChangesAsync(cancellationToken);
 
-        _logger.LogInformation($"Monthly statistics updated for channel {channel.Name} for year: {year}/ month: {month}");
+        _logger.LogInformation($"Monthly statistics updated for channel {channel.Name} for year: {year} / month: {month}");
 
     }
 }

--- a/src/IrcMonitor.RowInserterFunction/Functions/DailyRowAggregator.cs
+++ b/src/IrcMonitor.RowInserterFunction/Functions/DailyRowAggregator.cs
@@ -18,7 +18,7 @@ public class DailyRowAggregator
     [Function("DailyRowAggregator")]
     public async Task Run([QueueTrigger("daily-aggregates")] FormDailyAggregateModel content, FunctionContext context)
     {
-        _logger.LogInformation($"Start forming daily aggregate for channel id {content.ChannelId} / date {content.Date}.");
+        _logger.LogInformation($"Daily aggregate for channel id {content.ChannelId} / date {content.Date} triggered");
 
         await _statisticsService.UpdateChannelMonthlyStatistics(content.ChannelId, content.Date.Year, content.Date.Month, content.Date.Day, context.CancellationToken);
 

--- a/src/IrcMonitor.RowInserterFunction/Functions/DailyRowAggregator.cs
+++ b/src/IrcMonitor.RowInserterFunction/Functions/DailyRowAggregator.cs
@@ -1,5 +1,4 @@
 ﻿using IrcMonitor.Application.Common.Interfaces;
-using IrcMonitor.Domain.Models;
 using IrcMonitor.Domain.Models.Functions;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;

--- a/src/IrcMonitor.RowInserterFunction/Functions/DailyRowAggregator.cs
+++ b/src/IrcMonitor.RowInserterFunction/Functions/DailyRowAggregator.cs
@@ -1,5 +1,6 @@
 ﻿using IrcMonitor.Application.Common.Interfaces;
 using IrcMonitor.Domain.Models;
+using IrcMonitor.Domain.Models.Functions;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
@@ -16,13 +17,13 @@ public class DailyRowAggregator
     }
 
     [Function("DailyRowAggregator")]
-    public async Task Run([QueueTrigger("daily-aggregates")] ProcessLogFileReturnModel content, FunctionContext context)
+    public async Task Run([QueueTrigger("daily-aggregates")] FormDailyAggregateModel content, FunctionContext context)
     {
         _logger.LogInformation($"Start forming daily aggregate for channel id {content.ChannelId} / date {content.Date}.");
 
         await _statisticsService.UpdateChannelMonthlyStatistics(content.ChannelId, content.Date.Year, content.Date.Month, content.Date.Day, context.CancellationToken);
 
-        _logger.LogInformation($"Daily aggregates formed for channel id ${content.ChannelId}");
+        _logger.LogInformation($"Daily aggregates formed for channel id {content.ChannelId}");
 
         Console.WriteLine(content);
     }

--- a/src/IrcMonitor.RowInserterFunction/Functions/DailyRowAggregator.cs
+++ b/src/IrcMonitor.RowInserterFunction/Functions/DailyRowAggregator.cs
@@ -25,6 +25,5 @@ public class DailyRowAggregator
 
         _logger.LogInformation($"Daily aggregates formed for channel id {content.ChannelId}");
 
-        Console.WriteLine(content);
     }
 }

--- a/src/IrcMonitor.RowInserterFunction/Functions/DailyRowAggregator.cs
+++ b/src/IrcMonitor.RowInserterFunction/Functions/DailyRowAggregator.cs
@@ -1,0 +1,23 @@
+﻿using IrcMonitor.Application.Common.Interfaces;
+using IrcMonitor.Domain.Models;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace IrcMonitor.RowInserterFunction.Functions;
+
+public class DailyRowAggregator
+{
+    private readonly ILogger _logger;
+    private readonly IRowInsertService _rowInsertService;
+    public DailyRowAggregator(ILoggerFactory loggerFactory, IRowInsertService rowInsertService)
+    {
+        _logger = loggerFactory.CreateLogger<RowInserter>();
+        _rowInsertService = rowInsertService;
+    }
+
+    [Function("DailyRowAggregator")]
+    public async Task Run([QueueTrigger("daily-aggregates")] ProcessLogFileReturnModel content, FunctionContext context)
+    {
+        Console.WriteLine(content);
+    }
+}

--- a/src/IrcMonitor.RowInserterFunction/Functions/DailyRowAggregator.cs
+++ b/src/IrcMonitor.RowInserterFunction/Functions/DailyRowAggregator.cs
@@ -8,16 +8,22 @@ namespace IrcMonitor.RowInserterFunction.Functions;
 public class DailyRowAggregator
 {
     private readonly ILogger _logger;
-    private readonly IRowInsertService _rowInsertService;
-    public DailyRowAggregator(ILoggerFactory loggerFactory, IRowInsertService rowInsertService)
+    private readonly IStatisticsService _statisticsService;
+    public DailyRowAggregator(ILoggerFactory loggerFactory, IStatisticsService statisticsService)
     {
         _logger = loggerFactory.CreateLogger<RowInserter>();
-        _rowInsertService = rowInsertService;
+        _statisticsService = statisticsService;
     }
 
     [Function("DailyRowAggregator")]
     public async Task Run([QueueTrigger("daily-aggregates")] ProcessLogFileReturnModel content, FunctionContext context)
     {
+        _logger.LogInformation($"Start forming daily aggregate for channel id {content.ChannelId} / date {content.Date}.");
+
+        await _statisticsService.UpdateChannelMonthlyStatistics(content.ChannelId, content.Date.Year, content.Date.Month, content.Date.Day, context.CancellationToken);
+
+        _logger.LogInformation($"Daily aggregates formed for channel id ${content.ChannelId}");
+
         Console.WriteLine(content);
     }
 }

--- a/src/IrcMonitor.RowInserterFunction/Functions/RowAggregator.cs
+++ b/src/IrcMonitor.RowInserterFunction/Functions/RowAggregator.cs
@@ -23,7 +23,7 @@ namespace IrcMonitor.RowInserterFunction.Functions
 
             var response = req.CreateResponse(HttpStatusCode.OK);
 
-            await _statisticsService.PopulateChannelStatistics();
+            await _statisticsService.PopulateChannelStatistics(CancellationToken.None);
             
             response.Headers.Add("Content-Type", "text/plain; charset=utf-8");
 

--- a/src/IrcMonitor.RowInserterFunction/Functions/RowInserter.cs
+++ b/src/IrcMonitor.RowInserterFunction/Functions/RowInserter.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using IrcMonitor.Application.Common.Interfaces;
+using IrcMonitor.Domain.Models.Functions;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 
@@ -28,7 +29,13 @@ public class RowInserter
             return null;
         }
 
-        string jsonString = JsonSerializer.Serialize(res);
+        var retModel = new FormDailyAggregateModel()
+        {
+            ChannelId = res.Channel.Guid,
+            Date = res.Date
+        };
+
+        string jsonString = JsonSerializer.Serialize(retModel);
         return jsonString;
     }
 }

--- a/src/IrcMonitor.RowInserterFunction/Functions/RowInserter.cs
+++ b/src/IrcMonitor.RowInserterFunction/Functions/RowInserter.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using IrcMonitor.Application.Common.Interfaces;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
@@ -15,10 +16,19 @@ public class RowInserter
     }
 
     [Function("RowInserter")]
-    public async Task Run([BlobTrigger("irclogs/{name}", Connection = "storagestring")] string content, string name)
+    [QueueOutput("daily-aggregates")]
+    public async Task<string> Run([BlobTrigger("irclogs/{name}", Connection = "storagestring")] string content, string name)
     {
         _logger.LogInformation($"Start processing file with name {name}");
-        await _rowInsertService.ProcessFile(name, content);
+        var res = await _rowInsertService.ProcessFile(name, content);
         _logger.LogInformation($"Finished processing file with name {name}");
+
+        if (res == null)
+        {
+            return null;
+        }
+
+        string jsonString = JsonSerializer.Serialize(res);
+        return jsonString;
     }
 }

--- a/src/IrcMonitor.RowInserterFunction/Functions/RowInserter.cs
+++ b/src/IrcMonitor.RowInserterFunction/Functions/RowInserter.cs
@@ -17,7 +17,7 @@ public class RowInserter
 
     [Function("RowInserter")]
     [QueueOutput("daily-aggregates")]
-    public async Task<string> Run([BlobTrigger("irclogs/{name}", Connection = "storagestring")] string content, string name)
+    public async Task<string> Run([BlobTrigger("irclogs/{name}")] string content, string name)
     {
         _logger.LogInformation($"Start processing file with name {name}");
         var res = await _rowInsertService.ProcessFile(name, content);

--- a/src/IrcMonitor.WebUI/IrcMonitor.WebUI.csproj
+++ b/src/IrcMonitor.WebUI/IrcMonitor.WebUI.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
@@ -22,19 +22,19 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation.AspNetCore" Version="10.3.4" />
-    <PackageReference Include="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Version="7.0.0-rc.2.22476.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.0-rc.2.22476.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.0-rc.2.22476.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="7.0.0-rc.2.22476.2" />
-    <PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="7.0.0-rc.2.22476.2" />
+    <PackageReference Include="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Version="7.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="7.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="7.0.11" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices" Version="3.1.32" />
-    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="7.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.0-rc.2.22472.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0-rc.2.22472.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.0-rc.2.22472.11" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="6.0.10" />
-    <PackageReference Include="NSwag.AspNetCore" Version="13.16.0" />
-    <PackageReference Include="NSwag.MSBuild" Version="13.16.0">
+    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="7.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="7.0.11" />
+    <PackageReference Include="NSwag.AspNetCore" Version="13.20.0" />
+    <PackageReference Include="NSwag.MSBuild" Version="13.20.0">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
- Updated packages that very easily updatable, mainly EF / AspnetCore packages to version 7.0.11
  - Also, installed EF CORE bulk extensions.
- In the ``StatisticsService``, created the method ``UpdateChannelMonthlyStatistics`` to update the monthly aggregates for a channel.
  - Created a Azure queue triggered function, which calls the above method.
  - The blog trigger (when uploading files), now has an output binding to queue storage, from which daily / monthly aggregate forming then happens.
-  Removed the global filter for IsActive on IrcChannels, now just filtering accordingly in the ``GetIrcChannels``-query.