### PR TITLE
Fetch queue names from settings, enable usage of app secrets

### DIFF
--- a/src/IrcMonitor.RowInserterFunction/Functions/DailyRowAggregator.cs
+++ b/src/IrcMonitor.RowInserterFunction/Functions/DailyRowAggregator.cs
@@ -16,7 +16,7 @@ public class DailyRowAggregator
     }
 
     [Function("DailyRowAggregator")]
-    public async Task Run([QueueTrigger("daily-aggregates")] FormDailyAggregateModel content, FunctionContext context)
+    public async Task Run([QueueTrigger("%DailyAggregatesQueue%")] FormDailyAggregateModel content, FunctionContext context)
     {
         _logger.LogInformation($"Daily aggregate for channel id {content.ChannelId} / date {content.Date} triggered");
 

--- a/src/IrcMonitor.RowInserterFunction/Functions/RowInserter.cs
+++ b/src/IrcMonitor.RowInserterFunction/Functions/RowInserter.cs
@@ -17,10 +17,10 @@ public class RowInserter
     }
 
     [Function("RowInserter")]
-    [QueueOutput("daily-aggregates")]
+    [QueueOutput("%DailyAggregatesQueue%")]
     public async Task<string> Run(
-        [QueueTrigger("log-files-to-process")] string name,
-        [BlobInput("irclogs/{queueTrigger}")] string content
+        [QueueTrigger("%FilesToProcessQueueName%")] string name,
+        [BlobInput("%LogsContainer%/{queueTrigger}")] string content
         )
     {      
         _logger.LogInformation($"Start processing file with name {name}");

--- a/src/IrcMonitor.RowInserterFunction/local.settings.json
+++ b/src/IrcMonitor.RowInserterFunction/local.settings.json
@@ -1,8 +1,11 @@
 {
-    "IsEncrypted": false,
+  "IsEncrypted": false,
   "Values": {
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
-    "DBConnectionString": "Server=.\\SQLEXPRESS;Database=IrcMonitorDb;Trusted_Connection=True;MultipleActiveResultSets=true;Trust Server Certificate=true"
+    "DBConnectionString": "Server=.\\SQLEXPRESS;Database=IrcMonitorDb;Trusted_Connection=True;MultipleActiveResultSets=true;Trust Server Certificate=true",
+    "FilesToProcessQueueName": "log-files-to-process",
+    "DailyAggregatesQueue": "daily-aggregates-to-process",
+    "LogsContainer": "logs"
   }
 }


### PR DESCRIPTION
- Fetch queue names from settings, allow the usage of secrets.
- The settings inside the ``Values`` section of settings.local.json can be overridden with secrets (secrets.json), in which case it is not necessary to define the Values part.